### PR TITLE
Missing Spree namespace causes error on loading of slides_controller => show action

### DIFF
--- a/app/views/spree/admin/slides/show.html.erb
+++ b/app/views/spree/admin/slides/show.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'admin/shared/configuration_menu' %>
+<%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <h1><%= t(:slide) %></h1>
 


### PR DESCRIPTION
Hi, I don't know if this is an issue on my installation only. Thanks. 
