### PR TITLE
Added product association for Spree slides

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,0 +1,7 @@
+Spree::Product.class_eval do
+  has_one :slide, :dependent => :destroy
+  after_update :destroy_slide_if_deleted
+  def destroy_slide_if_deleted
+    slide.update_attributes(:published => false) if slide && deleted_at
+  end
+end

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -4,11 +4,20 @@ class Spree::Slide < ActiveRecord::Base
   attr_accessible :name, :body, :link_url, :published, :image, :position, :product_id
   belongs_to :product
 
+  def initialize(attrs = nil)
+    attrs ||= {:published => true}
+    super
+  end
+
   def slide_name
     name.blank? && product.present? ? product.name : name
   end
 
   def slide_link
     link_url.blank? && product.present? ? product : link_url
+  end
+
+  def slide_image
+    !image.file? && product.present? && product.images.any? ? product.images.first.attachment : image
   end
 end

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -2,4 +2,13 @@ class Spree::Slide < ActiveRecord::Base
   has_attached_file :image
   scope :published, where(:published => true)
   attr_accessible :name, :body, :link_url, :published, :image, :position, :product_id
+  belongs_to :product
+
+  def slide_name
+    name.blank? && product.present? ? product.name : name
+  end
+
+  def slide_link
+    link_url.blank? && product.present? ? product : link_url
+  end
 end

--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 <%= f.field_container :name do %>
   <%= f.label :name, t(:name) %><br />
-  <%= f.text_field :name %>
+  <%= f.text_field :name, :placeholder => t('spree_slider.placeholder_name') %>
 <% end %>
 <%= f.field_container :body do %>
   <%= f.label :body, t(:body) %><br />
@@ -12,10 +12,10 @@
 <% end %>
 <%= f.field_container :link_url do %>
   <%= f.label :link_url, t(:link_url) %><br />
-  <%= f.text_field :link_url %>
+  <%= f.text_field :link_url, :placeholder => t('spree_slider.placeholder_link_url') %>
 <% end %>
 <%= f.field_container :image do %>
-  <%= f.label :image, t(:image) %><br />
+  <%= f.label :image, t(:image) %> <i>(<%= t('spree_slider.image_tip') %>)</i><br />
   <%= f.file_field :image %>
 <% end %>
 <%= f.field_container :published do %>

--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -15,6 +15,8 @@
   <thead>
     <tr data-hook="admin_slides_index_headers">
       <th><%= t(:name) %></th>
+      <th><%= t(:product) %></th>
+      <th><%= t(:published) %></th>
       <th data-hook="admin_slides_index_header_position"><%= t(:position) %></th>
       <th data-hook="admin_slides_index_header_actions"></th>
     </tr>
@@ -22,7 +24,9 @@
   <tbody>
     <% @slides.each do |slide|%>
       <tr id="<%= dom_id slide %>" data-hook="admin_slides_index_rows">
-        <td width="350px" ><%=link_to slide.name, object_url(slide) %></td>
+        <td><%=link_to slide.name, object_url(slide) %></td>
+        <td><%=link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
+        <td><%=slide.published ? t(:y) : t(:n) %></td>
         <td data-hook="admin_slides_index_position"><%= slide.position %></td>
         <td data-hook="admin_slides_index_row_actions">
           <%= link_to_edit slide, :class => 'edit' %> &nbsp;

--- a/app/views/spree/admin/slides/show.html.erb
+++ b/app/views/spree/admin/slides/show.html.erb
@@ -3,6 +3,12 @@
 <h1><%= t(:slide) %></h1>
 
 <table>
+  <tr data-hook="product_id">
+    <th><%= t(:product) %></th>
+    <td>
+      <%= @slide.product.name unless @slide.product_id.blank? %>
+    </td>
+  </tr>
   <tr data-hook="name">
     <th><%= t(:name) %></th>
     <td>
@@ -24,7 +30,7 @@
   <tr data-hook="published">
     <th><%= t(:published) %></th>
     <td>
-      <%= @slide.published %>
+      <%= @slide.published ? t(:y) : t(:n) %>
     </td>
   </tr>
   <tr data-hook="image_file_name">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -21,3 +21,6 @@ de:
     title: "Slides"
     new_slide: "Neue Slide"
     editing_slide: "Bearbeiten Slide"
+    placeholder_name: "Leer lassen, um Produkt-Namen verwenden"
+    placeholder_link_url: "Leer lassen, um Produkt-URL verwenden"
+    image_tip: "Standard ersten product image"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -8,6 +8,8 @@ de:
   image_file_name: "Name der Bilddatei"
   published: "Veröffentlicht"
   position: "Position"
+  y: "Ja"
+  n: "Nein"
 
   activerecord:
     models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,6 @@ en:
     title: "Slides"
     new_slide: "New Slide"
     editing_slide: "Editing Slide"
+    placeholder_name: "Leave blank to use product name"
+    placeholder_link_url: "Leave blank to use product url"
+    image_tip: "Default first product image"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,8 @@ en:
   image_file_name: "Image file name"
   published: "Published"
   position: "Position"
+  y: "Yes"
+  n: "No"
 
   activerecord:
     models:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -8,6 +8,8 @@ es:
   image_file_name: "Nombre de la imagen"
   published: "Publicado"
   position: "Posición"
+  y: "Sí"
+  n: "No"
 
   activerecord:
     models:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,3 +21,6 @@ es:
     title: "Diapositivas"
     new_slide: "Nueva Diapositiva"
     editing_slide: "Editando Diapositiva"
+    placeholder_name: "En blanco para usar el del producto"
+    placeholder_link_url: "En blanco para usar la del producto"
+    image_tip: "Si no selecciona ninguna imagen, se tomará la primera del producto"

--- a/config/locales/nl-NL.yml
+++ b/config/locales/nl-NL.yml
@@ -21,3 +21,6 @@ nl-NL:
     title: "Slides"
     new_slide: "Nieuwe Slide"
     editing_slide: "Bewerken Van Slide"
+    placeholder_name: "Laat leeg om product naam te gebruiken"
+    placeholder_link_url: "Laat leeg om product url gebruiken"
+    image_tip: "Default eerste product afbeelding"

--- a/config/locales/nl-NL.yml
+++ b/config/locales/nl-NL.yml
@@ -8,6 +8,8 @@ nl-NL:
   image_file_name: "Bestandsnaam"
   published: "Gepubliceerd"
   position: "Positie"
+  y: "Ja"
+  n: "Geen"
 
   activerecord:
     models:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -8,6 +8,8 @@ nl:
   image_file_name: "Bestandsnaam"
   published: "Gepubliceerd"
   position: "Positie"
+  y: "Ja"
+  n: "Geen"
 
   activerecord:
     models:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -21,3 +21,6 @@ nl:
     title: "Slides"
     new_slide: "Nieuwe Slide"
     editing_slide: "Bewerken Van Slide"
+    placeholder_name: "Laat leeg om product naam te gebruiken"
+    placeholder_link_url: "Laat leeg om product url gebruiken"
+    image_tip: "Default eerste product afbeelding"

--- a/lib/generators/spree_slider/templates/anything_slider.html.erb
+++ b/lib/generators/spree_slider/templates/anything_slider.html.erb
@@ -1,7 +1,7 @@
 <% if Spree::Slide.published.count > 0 %>
   <!-- Define slider dimensions here -->
   <style>
-    #slider { width: 680px; height: 317px; } 
+    #slider { width: 680px; height: 317px; }
     .slider-wrapper { margin:0 auto 50px auto; }
   </style>
 
@@ -16,11 +16,8 @@
   <div class="slider-wrapper">
     <ul id="slider">
       <% Spree::Slide.published.order('position ASC').each do |s| %>
-        <li><%= link_to image_tag(s.image.url, :title => '#' + s.name.to_url), s.link_url %></li>
+        <li><%= link_to image_tag(s.slide_image.url, :title => '#' + s.slide_name.to_url), url_for(s.slide_link) %></li>
       <% end %>
     </ul>
   </div>
 <% end %>
-
-
-

--- a/lib/generators/spree_slider/templates/nivo_slider.html.erb
+++ b/lib/generators/spree_slider/templates/nivo_slider.html.erb
@@ -1,5 +1,5 @@
 <% if Spree::Slide.published.count > 0 %>
-  <style type="text/css"> 
+  <style type="text/css">
   .theme-default #slider {
       margin:0 auto 0 auto;
       width:618px; /* Make sure your images are the same size */
@@ -15,15 +15,15 @@
     <div id="slider" class="nivoSlider">
       <% Spree::Slide.published.order('position ASC').each do |s| %>
         <% if s.body != "" %>
-          <%= link_to image_tag(s.image.url, :title => '#' + s.name.to_url), s.link_url %>
+          <%= link_to image_tag(s.slide_image.url, :title => '#' + s.slide_name.to_url), url_for(s.slide_link) %>
         <% else %>
-          <%= link_to image_tag(s.image.url), s.link_url %>
+          <%= link_to image_tag(s.slide_image.url), url_for(s.slide_link) %>
         <% end %>
       <% end %>
     </div>
 
     <% Spree::Slide.published.order('position ASC').each do |s| %>
-      <div id='<%= s.name.to_url %>' class='nivo-html-caption'>
+      <div id='<%= s.slide_name.to_url %>' class='nivo-html-caption'>
         <%= s.body.html_safe %>
       </div>
     <% end %>
@@ -35,4 +35,3 @@
   });
   </script>
 <% end %>
-

--- a/lib/generators/spree_slider/templates/simple_carousel_slider.html.erb
+++ b/lib/generators/spree_slider/templates/simple_carousel_slider.html.erb
@@ -3,12 +3,12 @@
     <ul class="slider regular">
       <% Spree::Slide.published.order('position ASC').each do |s| %>
         <li>
-          <h1><%= s.name %></h1>
-          <%= link_to image_tag(s.image.url, :title => s.name.to_url), s.link_url %>
+          <h1><%= s.slide_name %></h1>
+          <%= link_to image_tag(s.slide_image.url, :title => s.slide_name.to_url), url_for(s.slide_link) %>
         </li>
       <% end %>
     </ul>
-    
+
     <a title="<%= t(:previous) %>" class="slider-prev"><%= t(:previous)%></a>
   	<a title="<%= t(:next) %>" class="slider-next"><%= t(:next) %></a>
   </section>


### PR DESCRIPTION
Hi! We have added a new field to the slides table (product_id). This allows to link a slide with a product, this way the name, image, and link url in the slide are, by default, the product ones.
So now in the view you can access to other product attributes such as price.
I hope you will find it useful.
Merry Christmas!!
