### PR TITLE
Support for spree 2-2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ group :test do
   end
 end
 
-gem 'spree', '~> 1.1.3'
+gem 'spree', '~> 2.2'
 
 gemspec

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -1,7 +1,7 @@
 class Spree::Slide < ActiveRecord::Base
 
   has_attached_file :image
-  validates_attachment :image, content_type: { ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
+  validates_attachment :image, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
   scope :published, -> { where(published: true).order('position ASC') }
 
   belongs_to :product

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -1,7 +1,7 @@
 class Spree::Slide < ActiveRecord::Base
 
   has_attached_file :image
-
+  validates_attachment :image, content_type: { ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
   scope :published, -> { where(published: true).order('position ASC') }
 
   belongs_to :product

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -1,8 +1,6 @@
 class Spree::Slide < ActiveRecord::Base
 
   has_attached_file :image
-  include Spree::Core::S3Support
-  supports_s3 :image
 
   scope :published, -> { where(published: true).order('position ASC') }
 

--- a/lib/generators/spree_slider/install_anything_generator.rb
+++ b/lib/generators/spree_slider/install_anything_generator.rb
@@ -6,9 +6,9 @@ module SpreeSlider
       copy_file "anything_slider.html.erb", "app/views/spree/shared/_slider.html.erb"      
       
       #add javascripts
-      append_file "app/assets/javascripts/store/all.js", "//= require js/jquery.anythingslider\n" 
-      append_file "app/assets/javascripts/store/all.js", "//= require js/jquery.anythingslider.fx\n" 
-      append_file "app/assets/javascripts/store/all.js", "//= require js/jquery.anythingslider.video\n" 
+      append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require js/jquery.anythingslider\n"
+      append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require js/jquery.anythingslider.fx\n"
+      append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require js/jquery.anythingslider.video\n"
 
       #add stylesheets
       inject_into_file "app/assets/stylesheets/store/all.css", " *= require css/anythingslider\n", :before => /\*\//, :verbose => true

--- a/lib/generators/spree_slider/install_nivo_generator.rb
+++ b/lib/generators/spree_slider/install_nivo_generator.rb
@@ -9,10 +9,10 @@ module SpreeSlider
       append_file "app/assets/javascripts/store/all.js", "//= require jquery.nivo.slider.pack.js\n" 
 
       #add stylesheets
-      inject_into_file "app/assets/stylesheets/store/all.css", " *= require themes/default/default\n", :before => /\*\//, :verbose => true
-      inject_into_file "app/assets/stylesheets/store/all.css", " *= require themes/pascal/pascal\n", :before => /\*\//, :verbose => true
-      inject_into_file "app/assets/stylesheets/store/all.css", " *= require themes/orman/orman\n", :before => /\*\//, :verbose => true
-      inject_into_file "app/assets/stylesheets/store/all.css", " *= require nivo-slider\n", :before => /\*\//, :verbose => true
+      inject_into_file "vendor/assets/javascripts/spree/frontend/all.css", " *= require themes/default/default\n", :before => /\*\//, :verbose => true
+      inject_into_file "vendor/assets/javascripts/spree/frontend/all.css", " *= require themes/pascal/pascal\n", :before => /\*\//, :verbose => true
+      inject_into_file "vendor/assets/javascripts/spree/frontend/all.css", " *= require themes/orman/orman\n", :before => /\*\//, :verbose => true
+      inject_into_file "vendor/assets/javascripts/spree/frontend/all.css", " *= require nivo-slider\n", :before => /\*\//, :verbose => true
 
       #copy migrations
       run 'bundle exec rake railties:install:migrations FROM=spree_slider' 

--- a/lib/generators/spree_slider/install_simple_carousel_generator.rb
+++ b/lib/generators/spree_slider/install_simple_carousel_generator.rb
@@ -6,8 +6,8 @@ module SpreeSlider
       copy_file "simple_carousel_slider.html.erb", "app/views/spree/shared/_slider.html.erb"      
       
       #add javascripts
-      append_file "app/assets/javascripts/store/all.js", "//= require simple.carousel\n" 
-      append_file "app/assets/javascripts/store/all.js", "//= require simple.carousel.slider\n" 
+      append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require simple.carousel\n"
+      append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require simple.carousel.slider\n"
       
       
       #copy migrations

--- a/spree_slider.gemspec
+++ b/spree_slider.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '>= 1.1.0'
+  s.add_dependency 'spree_core', '>= 2.2'
 end


### PR DESCRIPTION
Remove default S3Support as spree 2.2 removed it. 

Add attachment validators for newest version of paperclip
