### PR TITLE
Add crude publish_at feature; allow scheduling of slides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,4 @@ group :test do
   end
 end
 
-gem 'spree', '~> 2.2'
-
 gemspec

--- a/Versionfile
+++ b/Versionfile
@@ -2,3 +2,4 @@
 "1.1.x" => { :ref => "4f2c9e74e47e26b4f1fe67a59288d2cd45ccd13b" }
 "1.2.x" => { :ref => "4f2c9e74e47e26b4f1fe67a59288d2cd45ccd13b" }
 "2.0.x" => { :branch => "master" }
+"2.3.x" => { :branch => "2-3-stable" }

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -2,12 +2,12 @@ class Spree::Slide < ActiveRecord::Base
 
   has_attached_file :image
   validates_attachment :image, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
-  scope :published, -> { where(published: true).order('position ASC') }
+  scope :published, -> { where("published_at <= ?", Time.now).order('position ASC') }
 
   belongs_to :product, touch: true
 
   def initialize(attrs = nil)
-    attrs ||= {:published => true}
+    attrs ||= {:published_at => Time.now}
     super
   end
 

--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -22,8 +22,8 @@
   <%= f.file_field :image %>
 <% end %>
 <%= f.field_container :published do %>
-  <%= f.label :is_published, t(:published) %><br />
-  <%= f.check_box :published %>
+  <%= f.label :is_published, t(:published_at) %><br />
+  <%= f.text_field :published_at, :value => datepicker_field_value(@slide.published_at), :class => 'datepicker' %>
 <% end %>
 <%= f.field_container :position do %>
   <%= f.label :position, t(:position) %>

--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -14,7 +14,7 @@
     <th colspan="2"><%= Spree.t(:image) %></th>
     <th><%= Spree.t(:name) %></th>
     <th><%= Spree.t(:product) %></th>
-    <th><%= Spree.t(:published) %></th>
+    <th><%= Spree.t(:published_at) %></th>
     <th data-hook="admin_slides_index_header_actions" class="actions"></th>
   </tr>
   </thead>
@@ -27,7 +27,7 @@
       <td class="align-center"><%= image_tag slide.slide_image, style: 'width: 120px; height: auto;' %></td>
       <td><%= link_to slide.name, object_url(slide) %></td>
       <td><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
-      <td><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+      <td><%= slide.published_at %></td>
       <td data-hook="admin_slides_index_row_actions" class="actions">
         <%= link_to_edit slide, :no_text => true, :class => 'edit' %>
         &nbsp;

--- a/app/views/spree/admin/slides/show.html.erb
+++ b/app/views/spree/admin/slides/show.html.erb
@@ -28,9 +28,9 @@
     </td>
   </tr>
   <tr data-hook="published">
-    <th><%= t(:published) %></th>
+    <th><%= t(:published_at) %></th>
     <td>
-      <%= @slide.published ? t(:y) : t(:n) %>
+      <%= @slide.published_at %>
     </td>
   </tr>
   <tr data-hook="image_file_name">

--- a/db/migrate/20140619205843_change_published_to_timestamp.rb
+++ b/db/migrate/20140619205843_change_published_to_timestamp.rb
@@ -1,0 +1,13 @@
+class ChangePublishedToTimestamp < ActiveRecord::Migration
+  def up
+    add_column :spree_slides, :published_at, :timestamp
+    Spree::Slide.find_each do |slide|
+      slide.update_columns(published_at: slide.created_at) if slide.published
+    end
+    remove_column :spree_slides, :published
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spree_slider.gemspec
+++ b/spree_slider.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_slider'
-  s.version     = '1.2.0'
+  s.version     = '1.3.0'
   s.summary     = 'Spree Slider extension'
   s.description = 'Adds a slider to the homepage'
   s.required_ruby_version = '>= 1.8.7'
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '>= 2.2'
+  s.add_dependency 'spree_core', '~> 2.3'
 end


### PR DESCRIPTION
This changes the "publish" behaviour to be in line with the "available on" behaviour or products. 

Where "published" is not a flag, but rather a date after which the slide will be published. 

By leaving the date empty, a slide won't be available.

![schermafdruk van 2014-06-19 23 26 16](https://cloud.githubusercontent.com/assets/77059/3333917/c10db6ae-f7f8-11e3-8191-5d8974e32834.png)
