### PR TITLE
Tidy admin area

### DIFF
--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -1,32 +1,61 @@
-<%= f.field_container :product_id do %>
-  <%= label_tag :product_id, t(:product) %><br />
-  <%= hidden_field_tag 'slide[product_id]', f.object.product_id.to_s, :class => "product_picker fullwidth" %>
-<% end %>
-<%= f.field_container :name do %>
-  <%= f.label :name, t(:name) %><br />
-  <%= f.text_field :name, :placeholder => t('spree_slider.placeholder_name') %>
-<% end %>
-<%= f.field_container :body do %>
-  <%= f.label :body, t(:body) %><br />
-  <%= f.text_area :body, {:cols => 60, :rows => 4, :class => 'fullwidth'} %>
-<% end %>
-<%= f.field_container :link_url do %>
-  <%= f.label :link_url, t(:link_url) %><br />
-  <%= f.text_field :link_url, :placeholder => t('spree_slider.placeholder_link_url') %>
-<% end %>
-<%= f.field_container :image do %>
-  <%= f.label :image, t(:image) %> <i>(<%= t('spree_slider.image_tip') %>)</i><br />
-  <% if f.object.image? %>
-    <p><%= image_tag f.object.image, style: 'width: 120px; height: auto;' %></p>
-  <% end %>
-  <%= f.file_field :image %>
-<% end %>
-<%= f.field_container :published do %>
-  <%= f.label :is_published, t(:published) %><br />
-  <%= f.check_box :published %>
-<% end %>
-<%= f.field_container :position do %>
-  <%= f.label :position, t(:position) %>
-  <%= f.number_field :position %>
-<% end %>
+<div class="row">
+  <div class="alpha two columns">
+    <%= f.field_container :position do %>
+      <%= f.label :position, t(:position) %>
+      <%= f.number_field :position, :class => 'fullwidth' %>
+    <% end %>
+  </div>
 
+  <div class="omega ten columns">
+    <div class="field checkbox">
+      <label>
+        <%= f.check_box :published %>
+        <%= t(:published) %>
+      </label>
+    </div>
+  </div>
+
+  <div class="alpha omega twelve columns">
+    <%= f.field_container :product_id do %>
+      <%= label_tag :product_id, t(:product) %><br />
+      <%= hidden_field_tag 'slide[product_id]', f.object.product_id.to_s, :class => "product_picker fullwidth" %>
+    <% end %>
+  </div>
+
+  <div class="alpha six columns">
+    <%= f.field_container :name do %>
+      <%= f.label :name, t(:name) %><br />
+      <%= f.text_field :name, :class => 'fullwidth', :placeholder => t('spree_slider.placeholder_name') %>
+    <% end %>
+  </div>
+
+  <div class="omega six columns">
+    <%= f.field_container :link_url do %>
+      <%= f.label :link_url, t(:link_url) %><br />
+      <%= f.text_field :link_url, :class => 'fullwidth', :placeholder => t('spree_slider.placeholder_link_url') %>
+    <% end %>
+  </div>
+
+  <div class="alpha omega twelve columns">
+    <%= f.field_container :body do %>
+      <%= f.label :body, t(:body) %><br />
+      <%= f.text_area :body, {:cols => 60, :rows => 4, :class => 'fullwidth'} %>
+    <% end %>
+  </div>
+
+  <div class="alpha six columns">
+    <%= f.field_container :image do %>
+      <%= f.label :image, t(:image) %> <i>(<%= t('spree_slider.image_tip') %>)</i><br />
+      <%= f.file_field :image %>
+    <% end %>
+  </div>
+
+  <div class="omega six columns">
+    <%= f.field_container :image do %>
+      <% if f.object.image? %>
+        <p><%= image_tag f.object.image, style: 'max-width: 100%; height: auto;' %></p>
+      <% end %>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/spree/admin/slides/edit.html.erb
+++ b/app/views/spree/admin/slides/edit.html.erb
@@ -1,10 +1,25 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
-<h1><%= t('spree_slider.editing_slide') %></h1>
+<% content_for :page_title do %>
+  <%= t('spree_slider.editing_slide') %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to t('spree_slider.back_to_slides'), spree.admin_slides_path, :icon => 'arrow-left' %>
+  </li>
+<% end %>
 
 <%= render 'spree/shared/error_messages', :target => @slide %>
 
 <%= form_for [:admin, @slide], :html => { :multipart => true } do |f| %>
-  <%= render :partial => 'form', :locals => { :f => f } %>
-  <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'form', :locals => { :f => f } %>
+
+    <div class="clear"></div>
+
+    <div data-hook="admin_shipping_method_edit_form_buttons">
+      <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    </div>
+  </fieldset>
 <% end %>

--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -2,11 +2,13 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t('spree_slider.new_slide'), new_object_url, :icon => 'icon-plus', :id => 'admin_new_slide_link' %>
+    <%= button_link_to t('spree_slider.new_slide'), new_object_url, :icon => 'plus', :id => 'admin_new_slide_link' %>
   </li>
 <% end %>
 
-<h1><%= t('spree_slider.title') %></h1>
+<% content_for :page_title do %>
+  <%= t('spree_slider.title') %>
+<% end %>
 
 <table class="index sortable" id="listing_slides" data-hook data-sortable-link="<%= update_positions_admin_slides_url %>" >
   <thead>
@@ -25,9 +27,9 @@
         <span class="handle"></span>
       </td>
       <td class="align-center"><%= image_tag slide.slide_image, style: 'width: 120px; height: auto;' %></td>
-      <td><%= link_to slide.name, object_url(slide) %></td>
-      <td><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
-      <td><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+      <td class="align-center"><%= link_to slide.name, object_url(slide) %></td>
+      <td class="align-center"><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
+      <td class="align-center"><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
       <td data-hook="admin_slides_index_row_actions" class="actions">
         <%= link_to_edit slide, :no_text => true, :class => 'edit' %>
         &nbsp;

--- a/app/views/spree/admin/slides/new.html.erb
+++ b/app/views/spree/admin/slides/new.html.erb
@@ -1,9 +1,25 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
-<h1><%= t('spree_slider.new_slide') %></h1>
+<% content_for :page_title do %>
+  <%= t('spree_slider.new_slide') %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to t('spree_slider.back_to_slides'), spree.admin_slides_path, :icon => 'arrow-left' %>
+  </li>
+<% end %>
+
 <%= render 'spree/shared/error_messages', :target => @slide %>
 
 <%= form_for [:admin, @slide] , :html => { :multipart => true } do |f| %>
-  <%= render :partial => 'form', :locals => { :f => f } %>
-  <p class="form-buttons" data-hook="buttons"><%= button t(:create) %></p>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'form', :locals => { :f => f } %>
+
+    <div class="clear"></div>
+
+    <div data-hook="admin_shipping_method_new_form_buttons">
+      <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+    </div>
+  </fieldset>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
     title: "Slides"
     new_slide: "New Slide"
     editing_slide: "Editing Slide"
+    back_to_slides: "Back to Slides"
     placeholder_name: "Leave blank to use product name"
     placeholder_link_url: "Leave blank to use product url"
     image_tip: "Default first product image"


### PR DESCRIPTION
Make admin area more consistent with other spree admin views. See screenshots of updated views:

![screen shot 2014-09-26 at 10 56 10 pm](https://cloud.githubusercontent.com/assets/145042/4420712/b01efafc-457c-11e4-9371-a0bd55172c62.png)
![screen shot 2014-09-26 at 10 55 47 pm](https://cloud.githubusercontent.com/assets/145042/4420714/b0271ee4-457c-11e4-89b0-5eeaeb0dd792.png)
![screen shot 2014-09-26 at 10 55 35 pm](https://cloud.githubusercontent.com/assets/145042/4420713/b0263330-457c-11e4-9647-5f7d7cdd4f76.png)

PS thanks for this gem, it's great!
