### PR TITLE
Added :url, :path and :convert_options to Spree::Slide image attachment.

### DIFF
--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -1,6 +1,9 @@
 class Spree::Slide < ActiveRecord::Base
 
-  has_attached_file :image
+  has_attached_file :image,
+                    url: '/spree/slides/:id/:style/:basename.:extension',
+                    path: ':rails_root/public/spree/slides/:id/:style/:basename.:extension',
+                    convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
   validates_attachment :image, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
   scope :published, -> { where(published: true).order('position ASC') }
 


### PR DESCRIPTION
Store slider images next to other spree images. Should help to avoid server configuration issues. Additionally added the same convert options as in spree/image.rb
